### PR TITLE
feat(account): add account removal functionality

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,31 @@ pub fn load_accounts() -> Vec<Account> {
         .collect()
 }
 
+pub fn delete_account(name_to_delete: &str) -> io::Result<()> {
+    let accounts = load_accounts();
+    let updated_accounts: Vec<Account> = accounts
+        .into_iter()
+        .filter(|acc| acc.name != name_to_delete)
+        .collect();
+
+    let config_path = get_config_path();
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(&config_path)?;
+
+    for account in updated_accounts {
+        let entry = format!(
+            "{}|{}|{}|{}\n",
+            account.name, account.username, account.email, account.ssh_key
+        );
+        file.write_all(entry.as_bytes())?;
+    }
+    println!("🗑️ Account '{}' removed from config.", name_to_delete);
+    Ok(())
+}
+
 pub fn list_accounts() {
     let accounts = load_accounts();
     if accounts.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Arg, Command};
+use crate::commands::{add_account, list_accounts, use_account, remove_account};
 use crate::commands::{add_account, list_accounts, use_account};
 
 mod commands;
@@ -24,6 +25,11 @@ fn main() {
                 .arg(Arg::new("name").required(true).help("Name or username of the account to use")),
             )
         .subcommand(Command::new("list").about("List all saved Git accounts"))
+        .subcommand(
+            Command::new("remove")
+                .about("Remove a saved Git account and its SSH key")
+                .arg(Arg::new("name").required(true).help("Name of the account to remove")),
+        )
         .get_matches();
 
     match matches.subcommand() {
@@ -38,6 +44,13 @@ fn main() {
             use_account(name);
         }
         Some(("list", _)) => {
+            list_accounts();
+        }
+        Some(("remove", sub_m)) => {
+            let name = sub_m.get_one::<String>("name").unwrap();
+            remove_account(name);
+        }
+        _ => {
             list_accounts();
         }
         _ => {


### PR DESCRIPTION
Implement complete account removal including:
- Deleting account from config file
- Removing SSH config entry
- Deleting SSH key files Add new 'remove' command to CLI for account deletion